### PR TITLE
Changed update() and registerCommands()

### DIFF
--- a/src/ATCommands.cpp
+++ b/src/ATCommands.cpp
@@ -290,7 +290,7 @@ AT_COMMANDS_ERRORS ATCommands::update()
             {
                 this->error();
                 clearBuffer();
-                return;
+                return AT_COMMANDS_ERROR_SYNTAX;;
             }
 
             // process the command
@@ -356,6 +356,7 @@ bool ATCommands::registerCommands(const at_command_t *commands, uint32_t size)
 {
     atCommands = commands;
     numberOfCommands = (uint16_t)(size / sizeof(at_command_t));
+    return true;
 }
 
 /**


### PR DESCRIPTION
Added a return value to ATCommands::update(). Fixed ATCommands::registerCommands() by returning a boolean value. The error from ATCommands::registerCommands() causes my ESP32 to trigger an exception.